### PR TITLE
增加“制热”自动转“制冷”的功能

### DIFF
--- a/components/uart_vrf/__init__.py
+++ b/components/uart_vrf/__init__.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TIME_ID
 from esphome.components import uart
+from esphome.components import time as time_component
 
 
 DEPENDENCIES = ['uart']
@@ -14,6 +15,7 @@ UartVrfComponent = uart_vrf_ns.class_('UartVrfComponent', cg.Component, uart.UAR
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(UartVrfComponent),
+    cv.Optional(CONF_TIME_ID): cv.use_id(time_component.RealTimeClock),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 def to_code(config):
@@ -21,3 +23,7 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID], u)
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
+    
+    if CONF_TIME_ID in config:
+        time_ = yield cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time_id(time_))

--- a/components/uart_vrf/__init__.py
+++ b/components/uart_vrf/__init__.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TIME_ID
-from esphome.components import uart
-from esphome.components import time as time_component
+from esphome.const import CONF_ID
+from esphome.components import uart, binary_sensor
 
 
 DEPENDENCIES = ['uart']
@@ -10,20 +9,25 @@ AUTO_LOAD = ['climate']
 
 VRF_ID = 'uart_vrf_id'
 
+CONF_ALLOW_HEAT_MODE='allow_heat_mode'
+CONF_ALLOW_HEAT_MODE_SENSOR='allow_heat_mode_sensor'
+
 uart_vrf_ns = cg.esphome_ns.namespace('uart_vrf')
 UartVrfComponent = uart_vrf_ns.class_('UartVrfComponent', cg.Component, uart.UARTDevice)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(UartVrfComponent),
-    cv.Optional(CONF_TIME_ID): cv.use_id(time_component.RealTimeClock),
+    cv.Optional(CONF_ALLOW_HEAT_MODE_SENSOR): cv.use_id(binary_sensor.BinarySensor),
 }).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 
 def to_code(config):
     u = yield cg.get_variable(config["uart_id"])
     var = cg.new_Pvariable(config[CONF_ID], u)
+
+    # Add allow heat mode configuration
+    if CONF_ALLOW_HEAT_MODE_SENSOR in config:
+        allow_heat_sensor = yield cg.get_variable(config[CONF_ALLOW_HEAT_MODE_SENSOR])
+        cg.add(var.set_allow_heat_mode_sensor(allow_heat_sensor))
+
     yield cg.register_component(var, config)
     yield uart.register_uart_device(var, config)
-    
-    if CONF_TIME_ID in config:
-        time_ = yield cg.get_variable(config[CONF_TIME_ID])
-        cg.add(var.set_time_id(time_))

--- a/components/uart_vrf/uart_vrf_climate.cpp
+++ b/components/uart_vrf/uart_vrf_climate.cpp
@@ -4,11 +4,11 @@
 namespace esphome {
 namespace uart_vrf {
 
-static const char *const TAG = "uart_vrf.climate"; 
+static const char *const TAG = "uart_vrf.climate";
 
 void UartVrfClimate::setup() {
     ESP_LOGD(TAG, "UartVrfClimate::setup");
-    
+
     // Try to restore state
     auto restored = this->restore_state_();
     if (restored.has_value()) {
@@ -23,10 +23,10 @@ void UartVrfClimate::dump_config() {
 void UartVrfClimate::control(const climate::ClimateCall &call) {
     if (call.get_mode().has_value()) {
         climate::ClimateMode target_mode = *call.get_mode();
-        
-        // 如果是夏天且用户选择了制热模式，则强制改为制冷模式
-        if (target_mode == climate::ClimateMode::CLIMATE_MODE_HEAT && this->get_parent()->is_summer()) {
-            ESP_LOGD("uart_vrf.climate", "Summer detected, changing heat mode to cool mode");
+
+        // 如果不允许制热模式且用户选择了制热模式，则强制制冷
+        if (!this->get_parent()->is_heat_mode_allowed() &&
+            target_mode == climate::ClimateMode::CLIMATE_MODE_HEAT) {
             target_mode = climate::ClimateMode::CLIMATE_MODE_COOL;
         }
 

--- a/components/uart_vrf/uart_vrf_climate.cpp
+++ b/components/uart_vrf/uart_vrf_climate.cpp
@@ -22,7 +22,15 @@ void UartVrfClimate::dump_config() {
 
 void UartVrfClimate::control(const climate::ClimateCall &call) {
     if (call.get_mode().has_value()) {
-        this->mode = *call.get_mode();
+        climate::ClimateMode target_mode = *call.get_mode();
+        
+        // 如果是夏天且用户选择了制热模式，则强制改为制冷模式
+        if (target_mode == climate::ClimateMode::CLIMATE_MODE_HEAT && this->get_parent()->is_summer()) {
+            ESP_LOGD("uart_vrf.climate", "Summer detected, changing heat mode to cool mode");
+            target_mode = climate::ClimateMode::CLIMATE_MODE_COOL;
+        }
+
+        this->mode = target_mode;
 
         vrf_protocol::VrfCmd cmd;
         switch (this->mode) {

--- a/components/uart_vrf/uart_vrf_component.cpp
+++ b/components/uart_vrf/uart_vrf_component.cpp
@@ -343,21 +343,15 @@ void UartVrfComponent::query_next_climate() {
     }
 }
 
-bool UartVrfComponent::is_summer() {
-    if (this->time_id_ == nullptr) {
-        return false;
+bool UartVrfComponent::is_heat_mode_allowed() {
+    // 如果配置了传感器，则从传感器获取状态
+    if (this->allow_heat_mode_sensor_ != nullptr &&
+        this->allow_heat_mode_sensor_->has_state()) {
+        return this->allow_heat_mode_sensor_->state;
     }
-    
-    auto time = this->time_id_->now();
-    if (!time.is_valid()) {
-        return false;
-    }
-    
-    uint8_t month = time.month;
-    // 北半球夏天为6月、7月、8月
-    return (month >= 6 && month <= 8);
-}
 
+    return true;
+}
 
 } // namespace uart_vrf
 } // namespace esphome

--- a/components/uart_vrf/uart_vrf_component.cpp
+++ b/components/uart_vrf/uart_vrf_component.cpp
@@ -343,6 +343,21 @@ void UartVrfComponent::query_next_climate() {
     }
 }
 
+bool UartVrfComponent::is_summer() {
+    if (this->time_id_ == nullptr) {
+        return false;
+    }
+    
+    auto time = this->time_id_->now();
+    if (!time.is_valid()) {
+        return false;
+    }
+    
+    uint8_t month = time.month;
+    // 北半球夏天为6月、7月、8月
+    return (month >= 6 && month <= 8);
+}
+
 
 } // namespace uart_vrf
 } // namespace esphome

--- a/components/uart_vrf/uart_vrf_component.h
+++ b/components/uart_vrf/uart_vrf_component.h
@@ -4,7 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/components/uart/uart.h"
-#include "esphome/components/time/real_time_clock.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace vrf_protocol { // Forward declaration
   class VrfCmd;
@@ -61,9 +61,8 @@ public:
   void on_climate_create_callback(vrf_protocol::VrfClimate* climate);
   void on_climate_state_callback(vrf_protocol::VrfClimate* climate);
   void save_climate_state();
-  bool is_summer();
-
-  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+  bool is_heat_mode_allowed();
+  void set_allow_heat_mode_sensor(binary_sensor::BinarySensor *sensor) { this->allow_heat_mode_sensor_ = sensor; }
 
 protected:
   uart::UARTComponent* uart_;
@@ -75,7 +74,7 @@ protected:
   ESPPreferenceObject rtc_;
   bool climates_saved_{false};
   bool need_reboot_after_climates_saved_{false};
-  time::RealTimeClock *time_id_{nullptr};
+  binary_sensor::BinarySensor *allow_heat_mode_sensor_{nullptr};
 
   void fire_cmd();
   void find_climates();

--- a/components/uart_vrf/uart_vrf_component.h
+++ b/components/uart_vrf/uart_vrf_component.h
@@ -4,6 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/components/time/real_time_clock.h"
 
 namespace vrf_protocol { // Forward declaration
   class VrfCmd;
@@ -60,6 +61,9 @@ public:
   void on_climate_create_callback(vrf_protocol::VrfClimate* climate);
   void on_climate_state_callback(vrf_protocol::VrfClimate* climate);
   void save_climate_state();
+  bool is_summer();
+
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
 
 protected:
   uart::UARTComponent* uart_;
@@ -71,6 +75,7 @@ protected:
   ESPPreferenceObject rtc_;
   bool climates_saved_{false};
   bool need_reboot_after_climates_saved_{false};
+  time::RealTimeClock *time_id_{nullptr};
 
   void fire_cmd();
   void find_climates();

--- a/example/esp01s.yaml
+++ b/example/esp01s.yaml
@@ -14,9 +14,9 @@ uart:
     rx_pin: 3
     baud_rate: 9600
 
-uart_vrf:
 
-climate:
+uart_vrf:
+  allow_heat_mode_sensor: allow_heat_mode_sensor
 
 esp8266:
   board: esp01_1m
@@ -41,27 +41,23 @@ web_server:
   port: 80
   local: true
 
-debug:
-  update_interval: 60s
-
 switch:
+  - platform: restart
+    name: "重启设备 Reboot"
+    id: switch_reboot
   - platform: factory_reset
-    name: Reset
+    name: "恢复出厂配置 Reset"
+    id: switch_reset
+  - platform: template
+    name: "允许制热模式 Allow Heat"
+    id: allow_heat_mode_control
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
-text_sensor:
-  - platform: debug
-    device:
-      name: "Device Info"
-    reset_reason:
-      name: "Reset Reason"
-
-sensor:
-  - platform: debug
-    free:
-      name: "Heap Free"
-    fragmentation:
-      name: "Heap Fragmentation"
-    block:
-      name: "Heap Max Block"
-    loop_time:
-      name: "Loop Time"
+binary_sensor:
+  - platform: template
+    internal: True
+    name: "Allow Heat Mode Sensor"
+    id: allow_heat_mode_sensor
+    lambda: |-
+      return id(allow_heat_mode_control).state;

--- a/example/esp01s_even_nopass.yaml
+++ b/example/esp01s_even_nopass.yaml
@@ -16,8 +16,7 @@ uart:
     parity: EVEN
 
 uart_vrf:
-
-climate:
+  allow_heat_mode_sensor: allow_heat_mode_sensor
 
 esp8266:
   board: esp01_1m
@@ -40,29 +39,23 @@ web_server:
   port: 80
   local: true
 
-debug:
-  update_interval: 60s
-
 switch:
-  - platform: factory_reset
-    name: Reset
   - platform: restart
-    name: "Reboot"
+    name: "重启设备 Reboot"
+    id: switch_reboot
+  - platform: factory_reset
+    name: "恢复出厂配置 Reset"
+    id: switch_reset
+  - platform: template
+    name: "允许制热模式 Allow Heat"
+    id: allow_heat_mode_control
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
-text_sensor:
-  - platform: debug
-    device:
-      name: "Device Info"
-    reset_reason:
-      name: "Reset Reason"
-
-sensor:
-  - platform: debug
-    free:
-      name: "Heap Free"
-    fragmentation:
-      name: "Heap Fragmentation"
-    block:
-      name: "Heap Max Block"
-    loop_time:
-      name: "Loop Time"
+binary_sensor:
+  - platform: template
+    internal: True
+    name: "Allow Heat Mode Sensor"
+    id: allow_heat_mode_sensor
+    lambda: |-
+      return id(allow_heat_mode_control).state;

--- a/example/esp01s_nopass.yaml
+++ b/example/esp01s_nopass.yaml
@@ -15,8 +15,7 @@ uart:
     baud_rate: 9600
 
 uart_vrf:
-
-climate:
+  allow_heat_mode_sensor: allow_heat_mode_sensor
 
 esp8266:
   board: esp01_1m
@@ -39,27 +38,23 @@ web_server:
   port: 80
   local: true
 
-debug:
-  update_interval: 60s
-
 switch:
+  - platform: restart
+    name: "重启设备 Reboot"
+    id: switch_reboot
   - platform: factory_reset
-    name: Reset
+    name: "恢复出厂配置 Reset"
+    id: switch_reset
+  - platform: template
+    name: "允许制热模式 Allow Heat"
+    id: allow_heat_mode_control
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
-text_sensor:
-  - platform: debug
-    device:
-      name: "Device Info"
-    reset_reason:
-      name: "Reset Reason"
-
-sensor:
-  - platform: debug
-    free:
-      name: "Heap Free"
-    fragmentation:
-      name: "Heap Fragmentation"
-    block:
-      name: "Heap Max Block"
-    loop_time:
-      name: "Loop Time"
+binary_sensor:
+  - platform: template
+    internal: True
+    name: "Allow Heat Mode Sensor"
+    id: allow_heat_mode_sensor
+    lambda: |-
+      return id(allow_heat_mode_control).state;

--- a/example/esp01s_odd_nopass.yaml
+++ b/example/esp01s_odd_nopass.yaml
@@ -16,6 +16,7 @@ uart:
     parity: ODD
 
 uart_vrf:
+  allow_heat_mode_sensor: allow_heat_mode_sensor
 
 climate:
 
@@ -40,27 +41,23 @@ web_server:
   port: 80
   local: true
 
-debug:
-  update_interval: 60s
-
 switch:
+  - platform: restart
+    name: "重启设备 Reboot"
+    id: switch_reboot
   - platform: factory_reset
-    name: Reset
+    name: "恢复出厂配置 Reset"
+    id: switch_reset
+  - platform: template
+    name: "允许制热模式 Allow Heat"
+    id: allow_heat_mode_control
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
-text_sensor:
-  - platform: debug
-    device:
-      name: "Device Info"
-    reset_reason:
-      name: "Reset Reason"
-
-sensor:
-  - platform: debug
-    free:
-      name: "Heap Free"
-    fragmentation:
-      name: "Heap Fragmentation"
-    block:
-      name: "Heap Max Block"
-    loop_time:
-      name: "Loop Time"
+binary_sensor:
+  - platform: template
+    internal: True
+    name: "Allow Heat Mode Sensor"
+    id: allow_heat_mode_sensor
+    lambda: |-
+      return id(allow_heat_mode_control).state;

--- a/example/esp32wroom32d.yaml
+++ b/example/esp32wroom32d.yaml
@@ -18,10 +18,8 @@ external_components:
       type: git
       url: https://github.com/idreamshen/esphome-uart-vrf
 
-# Enable logging
 logger:
 
-# Enable Home Assistant API
 api:
   encryption:
     key: "vUAZJVUjuhi2kEiYRjjAwsSxuXVvUd1PTPNJWGNa2rs="
@@ -64,33 +62,29 @@ light:
     internal: true
 
 uart_vrf:
-
-climate:
+  allow_heat_mode_sensor: allow_heat_mode_sensor
 
 web_server:
   port: 80
   local: true
 
-debug:
-  update_interval: 60s
-
-button:
+switch:
+  - platform: restart
+    name: "重启设备 Reboot"
+    id: switch_reboot
   - platform: factory_reset
-    name: Reset Button
-    id: button_reset
+    name: "恢复出厂配置 Reset"
+    id: switch_reset
+  - platform: template
+    name: "允许制热模式 Allow Heat"
+    id: allow_heat_mode_control
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
-text_sensor:
-  - platform: debug
-    device:
-      name: "Device Info"
-    reset_reason:
-      name: "Reset Reason"
-
-sensor:
-  - platform: debug
-    free:
-      name: "Heap Free"
-    block:
-      name: "Heap Max Block"
-    loop_time:
-      name: "Loop Time"
+binary_sensor:
+  - platform: template
+    internal: True
+    name: "Allow Heat Mode Sensor"
+    id: allow_heat_mode_sensor
+    lambda: |-
+      return id(allow_heat_mode_control).state;


### PR DESCRIPTION
使用 HomeKit 桥接时，会调用 turn_on 方法，“制热”优先级高于“制冷”，故增加此开关用于强制模式转换